### PR TITLE
Separate function getHUfromCT into two

### DIFF
--- a/HUfromCT.py
+++ b/HUfromCT.py
@@ -342,6 +342,8 @@ def getHU(instORset, instORsetName, CTsliceDir, outfilename, resetCTOrigin, writ
     if result is None:
         print '\nError in getHUfromCT. Exiting'
         return
+    else:
+        interp = result
         
     # Map HU values to the int pnts of the FE model mesh
     print '\nMapping HU values to the int pnts of the FE model mesh'   


### PR DESCRIPTION
Separates function getHUfromCT into two functions. 
1. getHUfromCT - modified to only get the HU values from the CT stack. Returns an interpolation function
2. mapHUtoMesh - to perform the mapping of the HU values to the int pnts of the FE mesh
